### PR TITLE
Fix building LLVM master by passing CMAKE_BUILD_TYPE

### DIFF
--- a/tests/compilers/llvm-project-master.sh
+++ b/tests/compilers/llvm-project-master.sh
@@ -36,7 +36,7 @@ cd $SRC
 #------------------------------------------------
 mkdir build
 cd build
-cmake -DCMAKE_INSTALL_PREFIX=$INSTALL_PATH -DLLVM_ENABLE_PROJECTS="clang;flang;lld" -DLLVM_TARGETS_TO_BUILD="RISCV" ../llvm
+cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=$INSTALL_PATH -DLLVM_ENABLE_PROJECTS="clang;flang;lld" -DLLVM_TARGETS_TO_BUILD="RISCV" ../llvm
 if [ $? -ne 0 ]; then
   exit -1
 fi


### PR DESCRIPTION
Not defining CMAKE_BUILD_TYPE is an error since LLVM commit 350bdf92